### PR TITLE
Moved inner DOM layout inside the component

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 # ember-frost-button <br /> [![Travis][ci-img]][ci-url] [![Coveralls][cov-img]][cov-url] [![NPM][npm-img]][npm-url]
 
+ * [Installation](#Installation)
  * [API](#API)
  * [Examples](#Examples)
  * [Development](#Development)
@@ -20,62 +21,72 @@ ember install ember-frost-button
 
 ## API
 
-| Category | Name | Description |
-| -------- | ---- | ----------- |
-| **Actions** | `on-click` | triggers associated action |
-| **CSS (Content)** | `icon` | icon is part of the button |
-| | `icon-text` | icon and text are part of the button |
-| | `info` | additional info is part of the button |
-| | `text` | text is part of the button |
-| **CSS (Size)** | `small` | the smallest button you ever did see |
-| | `medium` | not quite as small as `small`, but not very big either |
-| | `large` | now we're getting somewhere  |
-| | `extra-large` | my grandma, what a big button you have! |
-| **CSS (TYPE)** | `primary` | default action on forms, etc. |
-| | `secondary` | average, garden-variety button |
-| | `tertiary` | subdued actions, like `Cancel` |
-| **States** | `autofocus` | wave your arms and make a big racket to attract everyone's attention as soon as you render |
-| | `disabled` | don't even think about trying to click this! |
+| Attribute | Type | Value | Description |
+| --------- | ---- | ----- | ----------- |
+| `autofocus` |`boolean` | `false` | **default**: Nothing to see here, just your average button |
+| | | `true` | Look at me! |
+| `disabled` | `boolean` | `false` | **default**: Click to your heart's content |
+| | | `true` | :no_entry_sign: Can't click this! :notes: |
+| `on-click` | `string` | `<action-name>` | triggers associated action when the button is clicked |
+| `icon` | `string` | `<icon-name>` | the name of a frost icon from `ember-frost-icons` |
+| `text` | `string` | `<button-text>` | text do display on the button |
+| `subtext` | `string` | `<button-subtext>` | subtext do display on the button underneath main `text` |
+| `size` | `string` | `small` | The smallest button you ever did see |
+| | | `medium` | **default**: Not quite as small as `small`, but not very big either |
+| | | `large` | Now *that's* what I call a button! |
+| | | `extra-large` | My grandma, what a big button you have! <br /> Recommended when `icon`, `text`, and `subtext` are used together |
+| `priority` | `string` | `primary` | Call-to-action :telephone: |
+| | | `secondary` | **default**: Run of the mill, garden variety  |
+| | | `tertiary` | Low-key, subdued  |
+| | | `confirm` | An alias for `primary`  |
+| | | `normal` | An alias for `secondary`  |
+| | | `cancel` | An alias for `tertiary`  |
 
 ## Examples
 
 ### Text
 ```handlebars
-{{#frost-button autofocus disabled=isDisabled class='primary small' on-click=(action 'closure')}}
-  <div class='text'>Text</div>
-{{/frost-button}
+{{frost-button
+  autofocus
+  disabled=isDisabled
+  on-click=(action 'closure')
+  priroty='primary'
+  size='small'
+  text='Text'
+}}
 ```
 
 ### Icon
 ```handlebars
-{{#frost-button class='tertiary medium' on-click=(action 'closure')}}
-  <div class='icon'>
-    {{frost-svg path='frost/add'}}
-  </div>
-{{/frost-button}}
+{{frost-button
+  icon='frost/add'
+  on-click=(action 'closure')
+  priority='tertiary'
+  size='medium'
+}}
 ```
 
 ### Icon Text
 ```handlebars
-{{#frost-button class='secondary large' on-click=(action 'closure')}}
-  <div class='icon-text'>
-    {{frost-svg path='frost/add'}}
-    <div class='text'>Text</div>
-  </div>
-{{/frost-button}}
+{{frost-button
+  icon='frost/add'
+  on-click=(action 'closure')
+  priority='secondary'
+  size='large'
+  text='Text'
+}}
 ```
 
 ### Info
 ```handlebars
-{{#frost-button class='primary extra-large' on-click=(action 'closure')}}
-  <div class='info'>
-    {{frost-svg path='frost/add'}}
-    <div class='content'>
-      <div class='alias'>Info alias</div>
-      <div class='details'>Info details</div>
-    </div>
-  </div>
-{{/frost-button}}
+{{frost-button
+  icon='frost/add'
+  on-click=(action 'closure')
+  priority='primary'
+  size='extra-large'
+  subtext='Subtext'
+  text='Main Text'
+}}
 ```
 
 ## Development
@@ -88,7 +99,9 @@ npm install && bower install
 
 ### Development Server
 A dummy application for development is available under `ember-frost-button/tests/dummy`.
-To run the server run `ember server` from the root of the repository and visit the app at http://localhost:4200.
+To run the server run `ember server` (or `npm start`) from the root of the repository and
+visit the app at http://localhost:4200.
 
 ### Testing
-Run `ember test` from the root of the project to execute the test suite and output code coverage.
+Run `npm test` from the root of the project to run linting checks as well as execute the test suite
+and output code coverage.

--- a/addon/components/frost-button.js
+++ b/addon/components/frost-button.js
@@ -1,5 +1,59 @@
 import Ember from 'ember'
+import layout from '../templates/components/frost-button'
 import _ from 'lodash/lodash'
+
+/**
+ * Add the appropriate class for the given priority to the Array of classes
+ * @param {String} priority - the priority to add
+ * @param {String[]} classes - the classes to add the priority class to
+ */
+function addPriorityClass (priority, classes) {
+  switch (priority) {
+    case 'confirm': // fallthrough
+    case 'primary':
+      classes.push('primary')
+      break
+    case 'normal': // fallthrough
+    case 'secondary':
+      classes.push('secondary')
+      break
+    case 'cancel': // fallthrough
+    case 'tertiary':
+      classes.push('tertiary')
+      break
+    default:
+      // no class to add for invalid priority
+      break
+  }
+}
+
+/**
+ * Add the appropriate class for the given size to the Array of classes
+ * Right now, this function seems a little odd/unnecessary, but we may want some
+ * aliases later, so we may as well have it set up like priority.
+ *
+ * @param {String} size - the size to add
+ * @param {String[]} classes - the classes to add the size class to
+ */
+function addSizeClass (size, classes) {
+  switch (size) {
+    case 'small':
+      classes.push('small')
+      break
+    case 'medium':
+      classes.push('medium')
+      break
+    case 'large':
+      classes.push('large')
+      break
+    case 'extra-large':
+      classes.push('extra-large')
+      break
+    default:
+      // no class to add for invalid size
+      break
+  }
+}
 
 export default Ember.Component.extend({
   tagName: 'button',
@@ -7,7 +61,8 @@ export default Ember.Component.extend({
     'frost-button'
   ],
   classNameBindings: [
-    'disabled'
+    'disabled',
+    'extraClasses'
   ],
   attributeBindings: [
     'autofocus',
@@ -18,8 +73,82 @@ export default Ember.Component.extend({
 
   autofocus: false,
   disabled: false,
+  layout,
   type: 'button',
+
   title: null,
+
+  /**
+   * Currently there are 3 levels of priority:
+   *
+   * 'primary' - a call-to-action button
+   * 'secondary' - a more standard/normal button
+   * 'tertiary' - a muted button (for things like cancel)
+   *
+   * We also support the following aliases for the above priorities
+   *
+   * 'confirm' => 'primary'
+   * 'normal' => 'secondary'
+   * 'cancel' => 'tertiary'
+   */
+  priority: 'confirm',
+
+  /**
+   * How big do you want your button?
+   * Currently available options are:
+   * ['small', 'medium', 'large', 'extra-large']
+   */
+  size: 'medium',
+
+  /**
+   * The text to display within this button
+   */
+  text: '',
+
+  /**
+   * The icon to display within this button
+   */
+  icon: '',
+
+  /**
+   * The subtext to display within this button (goes below the text)
+   */
+  subtext: '',
+
+  /**
+   * True if only the text property is given, and not icon or subtext
+   */
+  isTextOnly: Ember.computed('text', 'icon', 'subtext', function () {
+    return (this.get('text')) && !(this.get('icon') || this.get('subtext'))
+  }),
+
+  /**
+   * True if only the icon property is given, and not text or subtext
+   */
+  isIconOnly: Ember.computed('text', 'icon', 'subtext', function () {
+    return (this.get('icon')) && !(this.get('text') || this.get('subtext'))
+  }),
+
+  /**
+   * True if both the icon and text properties are given, but no subtext
+   */
+  isIconAndText: Ember.computed('text', 'icon', 'subtext', function () {
+    return ((this.get('icon') && this.get('text')) && !this.get('subtext'))
+  }),
+
+  /**
+   * True if all three properties of 'icon', 'text', and 'subtext' are given
+   */
+  isInfo: Ember.computed('text', 'icon', 'subtext', function () {
+    return (this.get('icon') && this.get('text') && this.get('subtext'))
+  }),
+
+  extraClasses: Ember.computed('priority', function () {
+    const classes = []
+    addSizeClass(this.get('size'), classes)
+    addPriorityClass(this.get('priority'), classes)
+    return classes.join(' ')
+  }),
 
   onclick: Ember.on('click', function (event) {
     if (!Ember.ViewUtils.isSimpleClick(event)) {

--- a/addon/styles/_frost-button.scss
+++ b/addon/styles/_frost-button.scss
@@ -5,6 +5,7 @@
   font-family: $frost-font-family;
   background-color: transparent;
   color: $frost-color-white;
+  cursor: pointer;
 
   &:focus, &:active {
     outline: none;
@@ -82,7 +83,7 @@
     padding: 0 30px 0 15px;
     font-size: $frost-font-size-3;
 
-    .frost-svg {
+    .frost-icon {
       width: 40px;
       height: 40px;
     }
@@ -93,7 +94,7 @@
     padding: 0 20px;
     font-size: $frost-font-size-3;
 
-    .frost-svg {
+    .frost-icon {
       width: 40px;
       height: 40px;
     }
@@ -104,7 +105,7 @@
     padding: 0 20px;
     font-size: $frost-font-size-2;
 
-    .frost-svg {
+    .frost-icon {
       width: 30px;
       height: 30px;
     }
@@ -115,7 +116,7 @@
     padding: 0 10px;
     font-size: $frost-font-size-1;
 
-    .frost-svg {
+    .frost-icon {
       width: 20px;
       height: 20px;
     }
@@ -165,12 +166,12 @@
       @include align-items(flex-start);
       padding-left: 10px;
 
-      .alias {
+      .text {
         font-size: $frost-font-size-3;
         color: $frost-color-white;
       }
 
-      .details {
+      .subtext {
         font-size: $frost-font-size-1;
         color: rgba($frost-color-white, 0.8);
       }

--- a/addon/templates/components/frost-button.hbs
+++ b/addon/templates/components/frost-button.hbs
@@ -1,0 +1,24 @@
+{{#if isTextOnly}}
+  <div class="text">{{text}}</div>
+{{/if}}
+{{#if isIconOnly}}
+  <div class="icon">
+    {{frost-icon icon=icon}}
+  </div>
+{{/if}}
+{{#if isIconAndText}}
+  <div class="icon-text text">
+    {{frost-icon icon=icon}}
+    <div class="text">{{text}}</div>
+  </div>
+{{/if}}
+{{#if isInfo}}
+  <div class="info">
+    {{frost-icon icon=icon}}
+    <div class='content'>
+      <div class='text'>{{text}}</div>
+      <div class='subtext'>{{subtext}}</div>
+    </div>
+  </div>
+{{/if}}
+{{yield}}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-data": "2.2.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
+    "ember-frost-icons": "^0.1.1",
     "ember-lodash": "^0.0.6",
     "ember-truth-helpers": "^1.2.0",
     "ember-try": "~0.0.8",

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -6,282 +6,321 @@
 
 <h2>frost-button</h2>
 
-<div class="example">
-  <div class="title">Primary</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='small primary'}}
-      <div class='text'>Action</div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='small primary'}}
-  <div class='text'>Action</div>
-{{/frost-button}}```"
-    }}
-  </div>
-</div>
-
-<div class="example">
-  <div class="title">Secondary</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='small secondary'}}
-      <div class="text">Action</div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='small secondary'}}
-  <div class=\"text\">Action</div>
-{{/frost-button}}
+<div class="section">
+  <div class="example">
+    <div class="title">Primary</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  on-click=(action 'click')
+  priority='confirm'
+  size='small'
+  text='Action'
+}}
 ```"
-    }}
-  </div>
-</div>
-
-<div class="example">
-  <div class="title">Tertiary</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='small tertiary'}}
-      <div class="text">Action</div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='small tertiary'}}
-  <div class=\"text\">Action</div>
-{{/frost-button}}
-```"
-    }}
-  </div>
-</div>
-
-<div class="example">
-  <div class="title">Small</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='small primary'}}
-      <div class="text">Action</div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='small primary'}}
-  <div class=\"text\">Action</div>
-{{/frost-button}}
-```"
-    }}
-  </div>
-</div>
-
-<div class="example">
-  <div class="title">Medium</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='medium primary'}}
-      <div class="text">Action</div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='medium primary'}}
-  <div class=\"text\">Action</div>
-{{/frost-button}}
-```"
-    }}
-  </div>
-</div>
-
-<div class="example">
-  <div class="title">Large</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='large primary'}}
-      <div class="text">Action</div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='large primary'}}
-  <div class=\"text\">Action</div>
-{{/frost-button}}
-```"
-    }}
-  </div>
-</div>
-
-<div class="example">
-  <div class="title">Disabled</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='small primary' disabled=true}}
-      <div class="text">Action</div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='small primary' disabled=true}}
-  <div class=\"text\">Action</div>
-{{/frost-button}}
-```"
-    }}
-  </div>
-</div>
-
-<div class="example">
-  <div class="title">Autofocus</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='small primary' autofocus=true}}
-      <div class="text">Action</div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='small primary' autofocus=true}}
-  <div class=\"text\">Action</div>
-{{/frost-button}}
-```"
-    }}
-  </div>
-</div>
-
-<div class="example">
-  <div class="title">Icon Small</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='small primary'}}
-      <div class="icon">
-        <svg class="frost-svg" viewBox="55 0 40 40">
-          <rect x="57.9" y="17.9" fill="#FFFFFF" width="33.3" height="4.1"></rect>
-          <rect x="72.5" y="3.3" fill="#FFFFFF" width="4.1" height="33.3"></rect>
-        </svg>
-      </div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='small primary'}}
-  <div class=\"icon\">
-    <svg class=\"frost-svg\" viewBox=\"55 0 40 40\">
-      <rect x=\"57.9\" y=\"17.9\" fill=\"#FFFFFF\" width=\"33.3\" height=\"4.1\"></rect>
-      <rect x=\"72.5\" y=\"3.3\" fill=\"#FFFFFF\" width=\"4.1\" height=\"33.3\"></rect>
-    </svg>
-  </div>
-{{/frost-button}}
-```"
-    }}
-  </div>
-</div>
-
-<div class="example">
-  <div class="title">Icon Medium</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='medium primary'}}
-      <div class="icon">
-        <svg class="frost-svg" viewBox="55 0 40 40">
-          <rect x="57.9" y="17.9" fill="#FFFFFF" width="33.3" height="4.1"></rect>
-          <rect x="72.5" y="3.3" fill="#FFFFFF" width="4.1" height="33.3"></rect>
-        </svg>
-      </div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='medium primary'}}
-  <div class=\"icon\">
-    <svg class=\"frost-svg\" viewBox=\"55 0 40 40\">
-      <rect x=\"57.9\" y=\"17.9\" fill=\"#FFFFFF\" width=\"33.3\" height=\"4.1\"></rect>
-      <rect x=\"72.5\" y=\"3.3\" fill=\"#FFFFFF\" width=\"4.1\" height=\"33.3\"></rect>
-    </svg>
-  </div>
-{{/frost-button}}
-```"
-    }}
-  </div>
-</div>
-
-<div class="example">
-  <div class="title">Icon Large</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='large primary'}}
-      <div class="icon">
-        <svg class="frost-svg" viewBox="55 0 40 40">
-          <rect x="57.9" y="17.9" fill="#FFFFFF" width="33.3" height="4.1"></rect>
-          <rect x="72.5" y="3.3" fill="#FFFFFF" width="4.1" height="33.3"></rect>
-        </svg>
-      </div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='large primary'}}
-  <div class=\"icon\">
-    <svg class=\"frost-svg\" viewBox=\"55 0 40 40\">
-      <rect x=\"57.9\" y=\"17.9\" fill=\"#FFFFFF\" width=\"33.3\" height=\"4.1\"></rect>
-      <rect x=\"72.5\" y=\"3.3\" fill=\"#FFFFFF\" width=\"4.1\" height=\"33.3\"></rect>
-    </svg>
-  </div>
-{{/frost-button}}
-```"
-    }}
-  </div>
-</div>
-
-<div class="example">
-  <div class="title">Icon and Info</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='extra-large primary'}}
-      <div class="info">
-        <svg class="frost-svg" viewBox="55 0 40 40">
-          <rect x="57.9" y="17.9" fill="#FFFFFF" width="33.3" height="4.1"></rect>
-          <rect x="72.5" y="3.3" fill="#FFFFFF" width="4.1" height="33.3"></rect>
-        </svg>
-        <div class='content'>
-          <div class='alias'>Info alias</div>
-          <div class='details'>Info details</div>
-        </div>
-      </div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='extra-large primary'}}
-  <div class=\"info\">
-    <svg class=\"frost-svg\" viewBox=\"55 0 40 40\">
-      <rect x=\"57.9\" y=\"17.9\" fill=\"#FFFFFF\" width=\"33.3\" height=\"4.1\"></rect>
-      <rect x=\"72.5\" y=\"3.3\" fill=\"#FFFFFF\" width=\"4.1\" height=\"33.3\"></rect>
-    </svg>
-    <div class='content'>
-      <div class='alias'>Info alias</div>
-      <div class='details'>Info details</div>
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        on-click=(action 'click')
+        priority='confirm'
+        size='small'
+        text='Action'
+      }}
     </div>
   </div>
-{{/frost-button}}
+
+  <div class="example">
+    <div class="title">Secondary</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  on-click=(action 'click')
+  priority='normal'
+  size='small'
+  text='Action'
+}}
 ```"
-    }}
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        on-click=(action 'click')
+        priority='normal'
+        size='small'
+        text='Action'
+      }}
+    </div>
+  </div>
+
+  <div class="example">
+    <div class="title">Tertiary</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  on-click=(action 'click')
+  priority='cancel'
+  size='small'
+  text='Action'
+}}
+```"
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        on-click=(action 'click')
+        priority='cancel'
+        size='small'
+        text='Action'
+      }}
+    </div>
   </div>
 </div>
 
-<div class="example">
-  <div class="title">Icon and Text</div>
-  <div class="demo">
-    {{#frost-button on-click=(action 'click') class='medium primary'}}
-      <div class="icon-text text">
-        <svg class="frost-svg" viewBox="55 0 40 40">
-          <rect x="57.9" y="17.9" fill="#FFFFFF" width="33.3" height="4.1"></rect>
-          <rect x="72.5" y="3.3" fill="#FFFFFF" width="4.1" height="33.3"></rect>
-        </svg>
-        <div class="text">Text</div>
-      </div>
-    {{/frost-button}}
-  </div>
-  <div class="code">
-    {{format-markdown "```handlebars
-{{#frost-button on-click=(action 'click') class='medium primary'}}
-  <div class=\"icon-text text\">
-    <svg class=\"frost-svg\" viewBox=\"55 0 40 40\">
-      <rect x=\"57.9\" y=\"17.9\" fill=\"#FFFFFF\" width=\"33.3\" height=\"4.1\"></rect>
-      <rect x=\"72.5\" y=\"3.3\" fill=\"#FFFFFF\" width=\"4.1\" height=\"33.3\"></rect>
-    </svg>
-    <div class=\"text\">Text</div>
-  </div>
-{{/frost-button}}
+<div class="section">
+  <div class="example">
+    <div class="title">Small</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  on-click=(action 'click')
+  priority='primary'
+  size='small'
+  text='Action'
+}}
 ```"
-    }}
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        on-click=(action 'click')
+        priority='primary'
+        size='small'
+        text='Action'
+      }}
+    </div>
+  </div>
+
+  <div class="example">
+    <div class="title">Medium</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  on-click=(action 'click')
+  size='medium'
+  priority='primary'
+  text='Action'
+}}
+```"
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        on-click=(action 'click')
+        priority='primary'
+        size='medium'
+        text='Action'
+      }}
+    </div>
+  </div>
+
+  <div class="example">
+    <div class="title">Large</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  on-click=(action 'click')
+  priority='primary'
+  size='large'
+  text='Action'
+}}
+```"
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        on-click=(action 'click')
+        size='large'
+        priority='primary'
+        text='Action'
+      }}
+    </div>
+  </div>
+</div>
+
+<div class="section">
+  <div class="example">
+    <div class="title">Icon Small</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  icon='frost/add'
+  on-click=(action 'click')
+  priority='primary'
+  size='small'
+}}
+```"
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        icon='frost/add'
+        on-click=(action 'click')
+        priority='primary'
+        size='small'
+      }}
+    </div>
+  </div>
+
+  <div class="example">
+    <div class="title">Icon Medium</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  icon='frost/add'
+  on-click=(action 'click')
+  priority='primary'
+  size='medium'
+}}
+```"
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        icon='frost/add'
+        on-click=(action 'click')
+        priority='primary'
+        size='medium'
+      }}
+    </div>
+  </div>
+
+  <div class="example">
+    <div class="title">Icon Large</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  icon='frost/add'
+  on-click=(action 'click')
+  priority='primary'
+  size='large'
+}}
+```"
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        icon='frost/add'
+        on-click=(action 'click')
+        priority='primary'
+        size='large'
+      }}
+    </div>
+  </div>
+</div>
+
+<div class="section">
+  <div class="example">
+    <div class="title">Disabled</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  disabled=true
+  on-click=(action 'click')
+  priority='primary'
+  size='small'
+  text='Action'
+}}
+```"
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        disabled=true
+        on-click=(action 'click')
+        priority='primary'
+        size='small'
+        text='Action'
+      }}
+    </div>
+  </div>
+
+  <div class="example">
+    <div class="title">Autofocus</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  autofocus=true
+  on-click=(action 'click')
+  priority='primary'
+  size='small'
+  text='Action'
+}}
+```"
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        autofocus=true
+        on-click=(action 'click')
+        priority='primary'
+        size='small'
+        text='Action'
+      }}
+    </div>
+  </div>
+</div>
+
+<div class="section">
+  <div class="example">
+    <div class="title">Icon and Info</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  icon='frost/add'
+  on-click=(action 'click')
+  priority='primary'
+  size='extra-large'
+  subtext='Subtext'
+  text='Text'
+}}
+```"
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        icon='frost/add'
+        on-click=(action 'click')
+        priority='primary'
+        size='extra-large'
+        subtext='Subtext'
+        text='Text'
+      }}
+    </div>
+  </div>
+
+  <div class="example">
+    <div class="title">Icon and Text</div>
+    <div class="code">
+      {{format-markdown "```handlebars
+{{frost-button
+  icon='frost/add'
+  on-click=(action 'click')
+  priority='primary'
+  size='medium'
+  text='Text'
+}}
+```"
+      }}
+    </div>
+    <div class="demo">
+      {{frost-button
+        icon='frost/add'
+        on-click=(action 'click')
+        priority='primary'
+        size='medium'
+        text='Text'
+      }}
+    </div>
   </div>
 </div>

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -16,6 +16,11 @@ html, body {
   margin: auto;
 }
 
+.section {
+  float: left;
+  padding-right: 30px;
+}
+
 th, td {
   padding: 5px;
   text-align: left;


### PR DESCRIPTION
This #feature# enables consumers to have much less knowledge of how to layout things within a button.

The most complicated buttons go from

``` handlebars
{{#frost-button
  class='extra-large primary'
  on-click=(action 'click') 
}}
  <div class="info">
    {{frost-icon icon='frost/add'}}
    <div class='content'>
      <div class='alias'>Text</div>
      <div class='details'>Subtext</div>
    </div>
  </div>
{{/frost-button}}
```

to

``` handlebars
{{frost-button
  icon='frost/add'
  on-click=(action 'click')
  priority='primary'
  size='extra-large'
  subtext='Subtext'
  text='Text'
}}
```
