### PR TITLE
Update engines to say node@5

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "index.js",
   "repository": "git@github.com:ciena-frost/ember-fr-button.git",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 5.0.0"
   },
   "author": "Steven Glanzer (https://github.com/sglanzer)",
   "contributors": [


### PR DESCRIPTION
This #patch# sets the engine to >=5.0.0 since our eslint configs
break with old npm
